### PR TITLE
RDKCOM-5358: RDKBDEV-3202 : OneWifi and WFO features should not force…

### DIFF
--- a/source/autowan.c
+++ b/source/autowan.c
@@ -160,10 +160,9 @@ void AutoWAN_main()
           AUTO_WAN_LOG("syscfg_get failed to retrieve ovs_enable\n");
 
     }
-    if( (0 == access( ONEWIFI_ENABLED, F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
-                                               || (access(WFO_ENABLED, F_OK) == 0 ) )
+    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
     {
-        AUTO_WAN_LOG("g_OvsEnable is set to 1 for OneWifi/WFO build\n");
+        AUTO_WAN_LOG("g_OvsEnable is set to 1\n");
         g_OvsEnable = 1;
     }
 #endif 


### PR DESCRIPTION
… platfo...

Reason for change: Usage of OneWifi and WFO features forces platform to use OVS
Test Procedure: Check the build
Risks: None
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>
Priority: P1

Change-Id: I98cd62108c9831c78f7dd7dcad6d286c5888d9ed (cherry picked from commit a9b9a259fea1c4fb6665abedbdfe7d7498ad4445)