### PR TITLE
Revert "RDKCOM-5358 to fix CBR2-2206: OneWifi and WFO features should not force platfo..."

### DIFF
--- a/source/autowan.c
+++ b/source/autowan.c
@@ -160,9 +160,10 @@ void AutoWAN_main()
           AUTO_WAN_LOG("syscfg_get failed to retrieve ovs_enable\n");
 
     }
-    if( 0 == access( OPENVSWITCH_LOADED, F_OK ) )
+    if( (0 == access( ONEWIFI_ENABLED, F_OK )) || (0 == access( OPENVSWITCH_LOADED, F_OK ))
+                                               || (access(WFO_ENABLED, F_OK) == 0 ) )
     {
-        AUTO_WAN_LOG("g_OvsEnable is set to 1\n");
+        AUTO_WAN_LOG("g_OvsEnable is set to 1 for OneWifi/WFO build\n");
         g_OvsEnable = 1;
     }
 #endif 


### PR DESCRIPTION
Reason for revert: To see if revert fixes CBR2-2206

This reverts commit 81c5442c2230bb903623d5fd80ca7546d6737911.

Change-Id: I6460e1a909d4e38030bb064b7023a02c0095e48c