### PR TITLE
RDKCOM-5448: RDKBDEV-3267 : Enable Security Flags and Improve Error Handling in gwprovapp

### DIFF
--- a/source/gw_prov_sm_generic.c
+++ b/source/gw_prov_sm_generic.c
@@ -1774,7 +1774,8 @@ pid_t findProcessId(char *processName)
 
     if ((f = popen(request, "r")) != NULL)
     {
-        fgets(response, (255), f);
+        if(fgets(response, (255), f) == NULL)
+            GWPROV_PRINT("%s fgets error \n", __FUNCTION__);
 
         pclose(f);
     }
@@ -1783,7 +1784,8 @@ pid_t findProcessId(char *processName)
 
     if ((f = popen(request, "r")) != NULL)
     {
-        fgets(response, (255), f);
+        if(fgets(response, (255), f) == NULL)
+            GWPROV_PRINT("%s fgets error \n", __FUNCTION__);
         pid = atoi(response);
         pclose(f);
     }


### PR DESCRIPTION
Reason for change:
The findProcessId function did not handle errors when reading process information using fgets. If fgets failed, it could lead to invalid data usage and compilation or runtime errors. Security flags were also enabled to improve application security.

FIX:

Added a check for the return value of fgets in findProcessId. If fgets returns NULL, an error message is logged using GWPROV_PRINT. Enabled security flags and resolved related compilation issues.

Test Procedure:

Start the build process for the updated gwprovapp source code. Monitor the build output for any compilation errors, especially generic errors like do_compile failed with exit code '1'. Ensure the build completes successfully without any compilation failures.