### PR TITLE
RDKB-63443 : Restrict LNF for residential mode

### DIFF
--- a/source/gw_prov_sm_generic.c
+++ b/source/gw_prov_sm_generic.c
@@ -1355,6 +1355,11 @@ static void *GWP_sysevent_threadfunc(void *data)
         if(true == isFeatureSupportedInCurrentMode(FEATURE_LNF))
         {
             sysevent_set(sysevent_fd_gs, sysevent_token_gs, "lnf-setup","6", 0);
+            t2_event_d("SYS_INFO_LNF_Enabled", 1);
+        }
+        else
+        {
+            t2_event_d("SYS_INFO_LNF_NotSupported", 1);
         }
 #else
         sysevent_set(sysevent_fd_gs, sysevent_token_gs, "lnf-setup","6", 0);


### PR DESCRIPTION
Reason for change: Add T2 markers
Test Procedure: Check for br106 interface
Risks: Low
Priority: P1

Related PR : https://github.com/rdkcentral/utopia/pull/271